### PR TITLE
Make rapidjson dependency managed at cmake configure step

### DIFF
--- a/epik/CMakeLists.txt
+++ b/epik/CMakeLists.txt
@@ -16,7 +16,8 @@ if (NOT DEFINED ENABLE_AVX512)
     set(ENABLE_AVX512 OFF)
 endif()
 
-find_package(RapidJSON REQUIRED)
+#find_package(RapidJSON REQUIRED)
+
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 if(ENABLE_OMP)
@@ -44,7 +45,7 @@ else()
     message(STATUS "EPIK: Vectorization DISABLED")
 endif()
 
-message(STATUS "RapidJSON: " ${RAPIDJSON_INCLUDE_DIRS})
+message(STATUS "RapidJSON: " ${RAPIDJSON_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIR})
 # RapidJSON cmake scripts are different between versions
 set(RapidJSON_INCLUDES ${RAPIDJSON_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIR})
 

--- a/epik/rapidjson.cmake
+++ b/epik/rapidjson.cmake
@@ -1,0 +1,22 @@
+include(ExternalProject)
+
+# Download RapidJSON
+ExternalProject_Add(
+    rapidjson
+    PREFIX "rapidjson"
+    GIT_REPOSITORY "https://github.com/Tencent/rapidjson.git"
+    GIT_TAG f54b0e47a08782a6131cc3d60f94d038fa6e0a51
+    TIMEOUT 10
+    CMAKE_ARGS
+        -DRAPIDJSON_BUILD_TESTS=OFF
+        -DRAPIDJSON_BUILD_DOC=OFF
+        -DRAPIDJSON_BUILD_EXAMPLES=OFF
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
+)
+
+# Prepare RapidJSON (RapidJSON is a header-only library)
+ExternalProject_Get_Property(rapidjson source_dir)
+set(RAPIDJSON_INCLUDE_DIRS ${source_dir}/include)


### PR DESCRIPTION
`rapidjson` is probably the least common dependency of EPIK.
While a reasonable version of boost will be present on most servers, this library will not.

This PR makes the dependency managed at configure time by cmake.
It just clones a fixed version from its repository and link the headers.
For me, this approach worked well on 2 different INRAE servers. The library was absent from the system and adding it via some environment would have been time-consuming (no root access).

Changes:

* `epik/rapidjson.cmake` manages the cloning at configure step.
* the last line `set(RAPIDJSON_INCLUDE_DIRS ${source_dir}/include)` makes sure it will be accessible by `epik/CMakeLists.txt`

I'm just not sure why you used 2 variables on the following lines of  this last file, but it did not interfere in my case:
```
# RapidJSON cmake scripts are different between versions
set(RapidJSON_INCLUDES ${RAPIDJSON_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIR})
```